### PR TITLE
Add functionality to get a module by a problemId

### DIFF
--- a/__tests__/module.routes.test.ts
+++ b/__tests__/module.routes.test.ts
@@ -184,6 +184,47 @@ describe('GET /', () => {
     expect(result.statusCode).toEqual(401);
   });
 
+  //getModulesByProblemId
+  //200 success test
+  it('checks /module/ByProblemId/:problemId GET route returns status 200 for a valid problemId', async () => {
+    const result: request.Response = await request(expressApp)
+      .get(`/v1/module/ByProblemId/${problem1.id}`)
+      .set('Authorization', 'bearer ' + token)
+      .send();
+    expect(result.statusCode).toEqual(200);
+    expect(result.body.name).toEqual(module1.name);
+    expect(result.body.number).toEqual(module1.number);
+  });
+
+  //getModulesByProblemId
+  //400 malformed request test
+  it('checks /module/ByProblemId/:problemId GET route returns status 400 for an ill-formed problemId', async () => {
+    const result: request.Response = await request(expressApp)
+      .get('/v1/module/ByProblemId/010101')
+      .set('Authorization', 'bearer ' + token)
+      .send();
+    expect(result.statusCode).toEqual(400);
+  });
+
+  //getModulesByProblemId
+  //401 unauthorized test
+  it('checks /module/ByProblemId/:problemId GET route returns status 400 for an ill-formed problemId', async () => {
+    const result: request.Response = await request(expressApp)
+      .get(`/v1/module/ByProblemId/${problem1.id}`)
+      .send();
+    expect(result.statusCode).toEqual(401);
+  });
+
+  //getModulesByProblemId
+  //404 not found test
+  it('checks /module/ByProblemId/:problemId GET route returns status 404 for a nonexistent problemId', async () => {
+    const result: request.Response = await request(expressApp)
+      .get('/v1/module/ByProblemId/012345678901234567890123')
+      .set('Authorization', 'bearer ' + token)
+      .send();
+    expect(result.statusCode).toEqual(404);
+  });
+
   // PUT Routes for Modules ------------------------------------------------------------
   // 200 SUCCESS Test
   it('checks /module/moduleId PUT route returns status 200 for updateModule', async () => {

--- a/src/api/controllers/module.controller.ts
+++ b/src/api/controllers/module.controller.ts
@@ -49,6 +49,7 @@ export const getModulesWithNonHiddenProblemsAndTestCases = async (
     res.status(400).send(err);
   }
 };
+
 export const getModuleByID = async (
   req: Request,
   res: Response
@@ -73,6 +74,24 @@ export const getModuleByID = async (
   } catch (err) {
     res.status(400).send(err);
   }
+};
+
+export const getModuleByProblemId = async (
+  req: Request,
+  res: Response
+): Promise<Response<any, Record<string, any>>> => {
+  if (!Types.ObjectId.isValid(req.params.problemId)) {
+    return res.status(400).send('This route requires a valid problem ID');
+  }
+  // Get all modules
+  let modules: ModuleInterface[] = await Module.find();
+  modules = modules.filter((doc) => {
+    return doc.problems.includes(new Types.ObjectId(req.params.problemId));
+  });
+  if (modules.length !== 1) {
+    return res.status(500).send('Multiple modules have this problemId');
+  }
+  return res.status(200).send(modules[0]);
 };
 
 export const getModulesWithProblems = async (

--- a/src/api/controllers/module.controller.ts
+++ b/src/api/controllers/module.controller.ts
@@ -88,7 +88,12 @@ export const getModuleByProblemId = async (
   modules = modules.filter((doc) => {
     return doc.problems.includes(new Types.ObjectId(req.params.problemId));
   });
-  if (modules.length !== 1) {
+  if (modules.length === 0) {
+    return res
+      .status(404)
+      .send('No module associated with this problemId was found');
+  }
+  if (modules.length > 1) {
     return res.status(500).send('Multiple modules have this problemId');
   }
   return res.status(200).send(modules[0]);

--- a/src/api/controllers/problem.controller.ts
+++ b/src/api/controllers/problem.controller.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from 'express';
 import { Module, ModuleDocument } from '../models/module.model';
 import { Problem, ProblemDocument } from '../models/problem.model';
-import problemValidation from '../validation/problem.validation';
+import {
+  problemValidation,
+  problemValidationWithoutModuleId
+} from '../validation/problem.validation';
 
 const readStudentProblems = async (
   req: Request,
@@ -145,7 +148,7 @@ const updateProblem = async (
   req: Request,
   res: Response
 ): Promise<Response<any, Record<string, any>>> => {
-  const { error } = problemValidation(req.body);
+  const { error } = problemValidationWithoutModuleId(req.body);
   if (error) {
     return res.status(400).send(error.details[0].message);
   }

--- a/src/api/routes/v1/module.routes.ts
+++ b/src/api/routes/v1/module.routes.ts
@@ -19,5 +19,8 @@ moduleRouter
   .get(modules.getModuleByID)
   .put(authenticateJWT, modules.putModule)
   .delete(authenticateJWT, modules.deleteModule);
+moduleRouter
+  .route('/ByProblemId/:problemId')
+  .get(authenticateJWT, modules.getModuleByProblemId);
 
 export { moduleRouter };

--- a/src/api/validation/problem.validation.ts
+++ b/src/api/validation/problem.validation.ts
@@ -39,4 +39,33 @@ const problemValidation = (data: any): ValidationResult => {
   return schema.validate(data);
 };
 
-export default problemValidation;
+const problemValidationWithoutModuleId = (data: any): ValidationResult => {
+  const schema = object({
+    moduleId: string().min(24).max(24),
+    statement: string().required(),
+    title: string().required(),
+    hidden: boolean().required(),
+    language: string().required(),
+    dueDate: date().iso().required(),
+    code: {
+      header: string().allow('').required(),
+      body: string().allow('').required(),
+      footer: string().allow('').required()
+    },
+    fileExtension: string().valid('.java', '.cpp', '.h').min(1).required(),
+    testCases: array().items({
+      input: string().required(),
+      expectedOutput: string().min(1).required(),
+      hint: string().required(),
+      visibility: number().valid(0, 1, 2).required()
+    }),
+    templatePackage: string().uri().required(),
+    timeLimit: number(),
+    memoryLimit: number(),
+    buildCommand: string()
+  });
+
+  return schema.validate(data);
+};
+
+export { problemValidation, problemValidationWithoutModuleId };


### PR DESCRIPTION
# Description
- Added a protected route to `GET` the module object associated with a `problemId`
- Added tests for this route
- Relaxed the validation for updating a problem so a `moduleId` is now optional

# Related Issue
N/A

# Motivation and Context
Allows frontend to lookup `module`s by a `problemId`

# How Has This Been Tested?
Tests have been added to `modules.routes.test.ts`
