### PR TITLE
Problem deletion now removes the problem from module.problems

### DIFF
--- a/__tests__/problem.routes.test.ts
+++ b/__tests__/problem.routes.test.ts
@@ -1,7 +1,7 @@
 import { expressApp } from '../src/config/express';
 import * as request from 'supertest';
 import { UserModel } from '../src/api/models/user.model';
-import { Module } from '../src/api/models/module.model';
+import { Module, ModuleInterface } from '../src/api/models/module.model';
 import { createSamplePayload } from '../mocks/problems';
 import * as bcrypt from 'bcrypt';
 import * as jwt from 'jsonwebtoken';
@@ -332,6 +332,14 @@ describe('GET /', () => {
       .send(sampleProblem);
     expect(postResult.statusCode).toEqual(200);
 
+    // Ensure module has one problem
+    const moduleAfterProblemAddedResult = await request(expressApp)
+      .get('/v1/module/WithProblems')
+      .set('Authorization', 'bearer ' + token);
+    let module: ModuleInterface = moduleAfterProblemAddedResult
+      .body[0] as ModuleInterface;
+    expect(module.problems.length).toEqual(1);
+
     let result = await request(expressApp)
       .get('/v1/admin/problem')
       .set('Authorization', 'bearer ' + token);
@@ -369,5 +377,12 @@ describe('GET /', () => {
       .set('Authorization', 'bearer ' + token);
     expect(result.statusCode).toEqual(200);
     expect(result.body.length).toEqual(0);
+
+    // Check that module.problems length is now 0
+    const moduleAfterProblemDeletedResult = await request(expressApp)
+      .get('/v1/module/WithProblems')
+      .set('Authorization', 'bearer ' + token);
+    module = moduleAfterProblemDeletedResult.body[0] as ModuleInterface;
+    expect(module.problems.length).toEqual(0);
   });
 });

--- a/src/api/controllers/problem.controller.ts
+++ b/src/api/controllers/problem.controller.ts
@@ -223,7 +223,7 @@ const deleteProblem = async (
     let i: number;
     for (i = 0; i < modules.length; i++) {
       modules[i].problems = modules[i].problems.filter((problemId) => {
-        problemId != new Types.ObjectId(req.params.problemId);
+        return problemId != new Types.ObjectId(req.params.problemId);
       }) as [Types.ObjectId];
     }
     modules.forEach(async (module) => {

--- a/src/api/controllers/problem.controller.ts
+++ b/src/api/controllers/problem.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { Types } from 'mongoose';
-import { Module, ModuleDocument, ModuleInterface } from '../models/module.model';
+import { Module, ModuleDocument } from '../models/module.model';
 import { Problem, ProblemDocument } from '../models/problem.model';
 import {
   problemValidation,
@@ -217,11 +217,11 @@ const deleteProblem = async (
       return res.status(404).send();
     }
     await problem.delete();
-    
+
     // Delete from problems array on each module
-    let modules: ModuleDocument[] = await Module.find();
+    const modules: ModuleDocument[] = await Module.find();
     let i: number;
-    for(i=0; i < modules.length; i++){
+    for (i = 0; i < modules.length; i++) {
       modules[i].problems = modules[i].problems.filter((problemId) => {
         problemId != new Types.ObjectId(req.params.problemId);
       }) as [Types.ObjectId];


### PR DESCRIPTION
# Description
Deleting a problem via `DELETE /admin/problem/:problemId` previously did not remove the `problemId` from its corresponding module's `problems` array. This PR fixes that. It also adds assertions on the size of the module's `problems` array to one of the tests in `__tests__/problem.routes.test.ts` to ensure that this added functionality works.

# Related Issue
#95 

# Motivation and Context
Explained above.

# How Has This Been Tested?
Via the test starting on line 327 of `__tests__/problem.routes.test.ts`