### PR TITLE
Fix empty hint bug

### DIFF
--- a/__tests__/problem.routes.test.ts
+++ b/__tests__/problem.routes.test.ts
@@ -64,6 +64,21 @@ describe('GET /', () => {
     expect(result.statusCode).toEqual(200);
   });
 
+  it('creates a problem with some empty fields and gets a 200 response', async () => {
+    let sampleProblem = createSamplePayload(moduleId);
+    sampleProblem.code.header = '';
+    sampleProblem.code.body = '';
+    sampleProblem.code.footer = '';
+    sampleProblem.testCases[0].hint = '';
+    sampleProblem.testCases[0].expectedOutput = '';
+    sampleProblem.buildCommand = '';
+    const result = await request(expressApp)
+      .post('/v1/admin/problem')
+      .set('Authorization', 'bearer ' + token)
+      .send(sampleProblem);
+    expect(result.statusCode).toEqual(200);
+  });
+
   it('attempts to create a problem with an invalid moduleId', async () => {
     const sampleProblem = createSamplePayload('invalidModuleId');
     const result = await request(expressApp)

--- a/__tests__/problem.routes.test.ts
+++ b/__tests__/problem.routes.test.ts
@@ -65,7 +65,7 @@ describe('GET /', () => {
   });
 
   it('creates a problem with some empty fields and gets a 200 response', async () => {
-    let sampleProblem = createSamplePayload(moduleId);
+    const sampleProblem = createSamplePayload(moduleId);
     sampleProblem.code.header = '';
     sampleProblem.code.body = '';
     sampleProblem.code.footer = '';

--- a/src/api/models/problem.model.ts
+++ b/src/api/models/problem.model.ts
@@ -72,12 +72,10 @@ const problemSchema = new Schema<ProblemInterface>(
           required: true
         },
         expectedOutput: {
-          type: String,
-          required: true
+          type: String
         },
         hint: {
-          type: String,
-          required: true
+          type: String
         },
         // visibility: 0, 1, or 2
         visibility: {


### PR DESCRIPTION
# Description
I added a test that would attempt to create a problem with empty strings for the fields that allow empty strings. Then I removed the `required: true` from these fields in `problem.model.ts`; this functionality is already implemented in `problem.validation.ts`.

# Related Issue
#84 

# Motivation and Context
#84

# How Has This Been Tested?
Added a test to `problem.routes.test.ts`.

# Screenshots (if appropriate):
