### PR TITLE
Add comments specifying time/memory units in Problem model

### DIFF
--- a/src/api/models/problem.model.ts
+++ b/src/api/models/problem.model.ts
@@ -20,8 +20,8 @@ interface ProblemInterface {
   fileExtension: string; //Interface doesn't enforce enum
   testCases: TestCase[];
   templatePackage: string;
-  timeLimit: number;
-  memoryLimit: number;
+  timeLimit: number; // in seconds
+  memoryLimit: number; // in KB
   buildCommand: string;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Added comments in `src/api/models/Problem.model.ts` which indicate the intended units for the `timeLimit` and `memoryLimit` members of the `Problem` interface. The comments were only added in the declaration of the `Problem` interface and not repeated later in the file (such as in the schema creation) to avoid redundancy.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issues: #114 

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change disambiguates the intended units for these attributes of `Problem` within the code, making the `Problem` code more digestible and well-documented.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As no functionality was changed, the change was tested only by running `npm run lint` and `npm run dev` to confirm that the comments adhered to code style rules and that the server was still launching correctly, respectively.

# Screenshots (if appropriate):
N/A