### PR TITLE
Fixed module ordering, organized course structure request

### DIFF
--- a/src/api/controllers/v2/module.controller.ts
+++ b/src/api/controllers/v2/module.controller.ts
@@ -100,6 +100,7 @@ export const changeContentOrder = async (
   let updatedContent: any;
   try {
     let orderNumber: number;
+    let moduleId: string;
 
     const payload: any = {
       orderNumber: req.body.newOrderNumber
@@ -110,12 +111,22 @@ export const changeContentOrder = async (
     if (req.body.contentType === 'problem') {
       const content = await ProblemDataLayer.getById(req.body.id);
       orderNumber = content.orderNumber;
+      moduleId = content.moduleId;
     } else if (req.body.contentType === 'lesson') {
       const content = await LessonDataLayer.getById(req.body.id);
       orderNumber = content.orderNumber;
+      moduleId = content.moduleId;
     } else {
       return res.status(400).send('Invalid/missing content type');
     }
+
+    const maxOrderNum = await ModuleDataLayer.getNextOrder(moduleId);
+    if (
+      req.body.newOrderNumber < 1 ||
+      req.body.newOrderNumber >= maxOrderNum ||
+      req.body.newOrderNumber === orderNumber
+    )
+      return res.status(400).send('Invalid order number');
 
     // shift the problems and lessons within the range
     await ProblemDataLayer.shiftProblems(

--- a/src/api/dal/course.ts
+++ b/src/api/dal/course.ts
@@ -56,10 +56,12 @@ export const getStructure = async (
   hidden: boolean
 ): Promise<CourseAttributes> => {
   const course = await Course.findByPk(courseId, {
+    attributes: ['id', 'courseName'],
     include: [
       {
         model: Module,
         as: 'modules',
+        attributes: ['id', 'moduleName'],
         include: [
           {
             model: Problem,
@@ -68,7 +70,9 @@ export const getStructure = async (
             where: {
               hidden: hidden
             },
-            attributes: ['id', 'title']
+            separate: true,
+            attributes: ['id', 'title', 'orderNumber'],
+            order: [['orderNumber', 'ASC']]
           },
           {
             model: Lesson,
@@ -77,7 +81,9 @@ export const getStructure = async (
             where: {
               hidden: hidden
             },
-            attributes: ['id', 'title']
+            separate: true,
+            attributes: ['id', 'title', 'orderNumber'],
+            order: [['orderNumber', 'ASC']]
           }
         ]
       }

--- a/src/api/dal/course.ts
+++ b/src/api/dal/course.ts
@@ -18,7 +18,7 @@ export const getById = async (
   id: string
 ): Promise<CourseAttributes | undefined> => {
   const course = await Course.findByPk(id);
-  return course ? course.dataValues : undefined;
+  return course ? course.get({ plain: true }) : undefined;
 };
 
 export const deleteById = async (id: string): Promise<boolean> => {
@@ -48,7 +48,7 @@ export const getAll = async (
       organizationId
     }
   });
-  return courses.map((value) => value.dataValues);
+  return courses.map((value) => value.get({ plain: true }));
 };
 
 export const getStructure = async (
@@ -89,5 +89,6 @@ export const getStructure = async (
       }
     ]
   });
-  return course ? course.dataValues : null;
+
+  return course ? course.get({ plain: true }) : null;
 };

--- a/src/api/dal/lesson.ts
+++ b/src/api/dal/lesson.ts
@@ -11,12 +11,12 @@ export const create = async (
   payload: LessonAttributesInput
 ): Promise<LessonAttributes> => {
   const lesson = await Lesson.create(payload);
-  return lesson.dataValues;
+  return lesson.get({ plain: true });
 };
 
 export const getById = async (id: string): Promise<LessonAttributes> => {
   const lesson = await Lesson.findByPk(id);
-  return lesson ? lesson.dataValues : null;
+  return lesson ? lesson.get({ plain: true }) : null;
 };
 
 export const deleteById = async (id: string): Promise<boolean> => {
@@ -42,19 +42,19 @@ export const updateById = async (
     return undefined;
   }
   const updatedLesson = await lesson.update(payload);
-  return updatedLesson.dataValues;
+  return updatedLesson.get({ plain: true });
 };
 
 export const getAll = async (): Promise<LessonAttributes[]> => {
   const lessons = await Lesson.findAll();
-  return lessons.map((value) => value.dataValues);
+  return lessons.map((value) => value.get({ plain: true }));
 };
 
 export const shiftLessons = async (
   moduleId: string,
   orderNumber: number,
   newOrderNumber?: number
-) => {
+): Promise<void> => {
   if (!newOrderNumber) {
     await Lesson.update(
       { orderNumber: sequelize.literal('orderNumber - 1') },

--- a/src/api/dal/lesson.ts
+++ b/src/api/dal/lesson.ts
@@ -4,6 +4,9 @@ import {
   Lesson
 } from '../models/v2/lesson.model';
 
+import { Op } from 'sequelize';
+import { sequelize } from '../../config/database_v2';
+
 export const create = async (
   payload: LessonAttributesInput
 ): Promise<LessonAttributes> => {
@@ -45,4 +48,41 @@ export const updateById = async (
 export const getAll = async (): Promise<LessonAttributes[]> => {
   const lessons = await Lesson.findAll();
   return lessons.map((value) => value.dataValues);
+};
+
+export const shiftLessons = async (
+  moduleId: string,
+  orderNumber: number,
+  newOrderNumber?: number
+) => {
+  if (!newOrderNumber) {
+    await Lesson.update(
+      { orderNumber: sequelize.literal('orderNumber - 1') },
+      {
+        where: {
+          moduleId: moduleId,
+          orderNumber: { [Op.gt]: orderNumber }
+        }
+      }
+    );
+  } else {
+    await Lesson.update(
+      {
+        orderNumber: sequelize.literal(
+          orderNumber < newOrderNumber ? 'orderNumber - 1' : 'orderNumber + 1'
+        )
+      },
+      {
+        where: {
+          moduleId: moduleId,
+          orderNumber: {
+            [Op.gte]:
+              orderNumber < newOrderNumber ? orderNumber : newOrderNumber,
+            [Op.lte]:
+              orderNumber < newOrderNumber ? newOrderNumber : orderNumber
+          }
+        }
+      }
+    );
+  }
 };

--- a/src/api/dal/module.ts
+++ b/src/api/dal/module.ts
@@ -16,8 +16,11 @@ export const create = async (
 
 export const getById = async (id: string): Promise<ModuleAttributes> => {
   const module_ = await Module.findByPk(id, {
-    include: 'problems',
-    order: [['problems', 'orderNumber', 'ASC']]
+    include: ['problems', 'lessons'],
+    order: [
+      ['problems', 'orderNumber', 'ASC'],
+      ['lessons', 'orderNumber', 'ASC']
+    ]
   });
   return module_ ? module_.dataValues : null;
 };
@@ -66,4 +69,10 @@ export const getAll = async (): Promise<ModuleAttributes[]> => {
     ]
   });
   return module_.map((value) => value.dataValues);
+};
+
+export const getNextOrder = async (id: string): Promise<number> => {
+  const module_ = await getById(id);
+  const prevMax = module_['problems'].length + module_['lessons'].length;
+  return prevMax + 1;
 };

--- a/src/api/dal/module.ts
+++ b/src/api/dal/module.ts
@@ -11,7 +11,7 @@ export const create = async (
   payload: ModuleAttributesInput
 ): Promise<ModuleAttributes> => {
   const module_ = await Module.create(payload);
-  return module_.dataValues;
+  return module_.get({ plain: true });
 };
 
 export const getById = async (id: string): Promise<ModuleAttributes> => {
@@ -22,7 +22,7 @@ export const getById = async (id: string): Promise<ModuleAttributes> => {
       ['lessons', 'orderNumber', 'ASC']
     ]
   });
-  return module_ ? module_.dataValues : null;
+  return module_ ? module_.get({ plain: true }) : null;
 };
 
 export const deleteById = async (id: string): Promise<boolean> => {
@@ -37,7 +37,7 @@ export const deleteByCourse = async (courseId: string): Promise<boolean> => {
     where: { courseId: courseId },
     attributes: ['id']
   });
-  const modules = moduleRows.map((module_) => module_.dataValues);
+  const modules = moduleRows.map((module_) => module_.get({ plain: true }));
 
   const numberOfDeletions = await Module.destroy({
     where: { courseId: courseId }
@@ -57,7 +57,7 @@ export const updateById = async (
   const module_ = await Module.findByPk(id);
   if (!module_) return undefined;
   const updatedModule = await module_.update(payload);
-  return updatedModule.dataValues;
+  return updatedModule.get({ plain: true });
 };
 
 export const getAll = async (): Promise<ModuleAttributes[]> => {
@@ -68,7 +68,7 @@ export const getAll = async (): Promise<ModuleAttributes[]> => {
       ['lessons', 'orderNumber', 'ASC']
     ]
   });
-  return module_.map((value) => value.dataValues);
+  return module_.map((value) => value.get({ plain: true }));
 };
 
 export const getNextOrder = async (id: string): Promise<number> => {

--- a/src/api/dal/organization.ts
+++ b/src/api/dal/organization.ts
@@ -8,19 +8,19 @@ export const create = async (
   payload: OrganizationAttributesInput
 ): Promise<OrganizationAttributes> => {
   const organization = await Organization.create(payload);
-  return organization.dataValues;
+  return organization.get({ plain: true });
 };
 
 export const getById = async (
   id: string
 ): Promise<OrganizationAttributes | undefined> => {
   const organization = await Organization.findByPk(id);
-  return organization ? organization.dataValues : undefined;
+  return organization ? organization.get({ plain: true }) : undefined;
 };
 
 export const getAll = async (): Promise<OrganizationAttributes[]> => {
   const org = await Organization.findAll();
-  return org.map((value) => value.dataValues);
+  return org.map((value) => value.get({ plain: true }));
 };
 
 export const deleteById = async (id: string): Promise<boolean> => {
@@ -40,5 +40,5 @@ export const updateById = async (
   }
 
   const updatedOrganization = await organization.update(payload);
-  return updatedOrganization.dataValues;
+  return updatedOrganization.get({ plain: true });
 };

--- a/src/api/dal/problem.ts
+++ b/src/api/dal/problem.ts
@@ -14,14 +14,14 @@ export const create = async (
   payload: ProblemAttributesInput
 ): Promise<ProblemAttributes> => {
   const problem = await Problem.create(payload);
-  return problem.dataValues;
+  return problem.get({ plain: true });
 };
 
 export const createTestCase = async (
   payload: TestCaseAttributesInput
 ): Promise<TestCaseAttributes> => {
   const testCase = await TestCase.create(payload);
-  return testCase.dataValues;
+  return testCase.get({ plain: true });
 };
 
 export const getById = async (id: string): Promise<ProblemAttributes> => {
@@ -29,7 +29,7 @@ export const getById = async (id: string): Promise<ProblemAttributes> => {
     include: 'testCases',
     order: [['testCases', 'orderNumber', 'ASC']]
   });
-  return problem ? problem.dataValues : null;
+  return problem ? problem.get({ plain: true }) : null;
 };
 
 export const deleteById = async (id: string): Promise<boolean> => {
@@ -55,7 +55,7 @@ export const updateById = async (
     return undefined;
   }
   const updatedProblem = await problem.update(payload);
-  return updatedProblem.dataValues;
+  return updatedProblem.get({ plain: true });
 };
 
 export const getByModule = async (
@@ -72,14 +72,14 @@ export const getByModule = async (
     include: 'testCases',
     order: [['testCases', 'orderNumber', 'ASC']]
   });
-  return problems.map((value) => value.dataValues);
+  return problems.map((value) => value.get({ plain: true }));
 };
 
 export const shiftProblems = async (
   moduleId: string,
   orderNumber: number,
   newOrderNumber?: number
-) => {
+): Promise<void> => {
   if (!newOrderNumber) {
     await Problem.update(
       { orderNumber: sequelize.literal('orderNumber - 1') },

--- a/src/api/models/v2/lesson.model.ts
+++ b/src/api/models/v2/lesson.model.ts
@@ -11,7 +11,10 @@ export interface LessonAttributes {
   orderNumber: number; // order of the lesson in the module
 }
 
-export type LessonAttributesInput = Optional<LessonAttributes, 'id'>;
+export type LessonAttributesInput = Optional<
+  LessonAttributes,
+  'id' | 'orderNumber'
+>;
 
 type LessonInstance = Model<LessonAttributes, LessonAttributesInput>;
 

--- a/src/api/models/v2/problem.model.ts
+++ b/src/api/models/v2/problem.model.ts
@@ -34,7 +34,7 @@ export interface TestCaseAttributes {
   problemId?: string;
 }
 
-export type ProblemAttributesInput = Optional<ProblemAttributes, 'id'>;
+export type ProblemAttributesInput = Optional<ProblemAttributes, 'id' | 'orderNumber'>;
 export type TestCaseAttributesInput = Optional<TestCaseAttributes, 'id'>;
 
 type ProblemInstance = Model<ProblemAttributes, ProblemAttributesInput>;

--- a/src/api/models/v2/problem.model.ts
+++ b/src/api/models/v2/problem.model.ts
@@ -34,7 +34,10 @@ export interface TestCaseAttributes {
   problemId?: string;
 }
 
-export type ProblemAttributesInput = Optional<ProblemAttributes, 'id' | 'orderNumber'>;
+export type ProblemAttributesInput = Optional<
+  ProblemAttributes,
+  'id' | 'orderNumber'
+>;
 export type TestCaseAttributesInput = Optional<TestCaseAttributes, 'id'>;
 
 type ProblemInstance = Model<ProblemAttributes, ProblemAttributesInput>;

--- a/src/api/routes/v2/module.routes.ts
+++ b/src/api/routes/v2/module.routes.ts
@@ -16,8 +16,8 @@ moduleRouter
   .put(modules.putModule)
   .delete(modules.deleteModule);
 moduleRouter
-  .route('/:moduleId/changeProblemOrder')
-  .post(modules.changeProblemOrder);
+  .route('/:moduleId/changeContentOrder')
+  .post(modules.changeContentOrder);
 //
 moduleRouter.route('/ByProblemId/:problemId').get(modules.getModuleByProblemId);
 

--- a/src/config/express.ts
+++ b/src/config/express.ts
@@ -50,12 +50,12 @@ class Server {
   }
 
   private async syncModels(): Promise<void> {
-    await Course.sync({ alter: true });
-    await Organization.sync({ alter: true });
-    await Module.sync({ alter: true });
-    await Problem.sync({ alter: true });
-    await TestCase.sync({ alter: true });
-    await Lesson.sync({ alter: true });
+    await Course.sync();
+    await Organization.sync();
+    await Module.sync();
+    await Problem.sync();
+    await TestCase.sync();
+    await Lesson.sync();
   }
 
   public start(): void {


### PR DESCRIPTION
We needed to combine lesson and problem ordering within a module.

# Description
- Changed lesson and problem ordering to work out of the same list
- Automated new problems/lessons to have an orderNumber that is the largest within the module
- Added a draggable orderNumber swap, instead of the older order swap, which was only up and down directions
- Cleaned up what is returned from the course structure endpoint, it now has problems and lessons combined into one content array, which is sorted by merging the order numbers from the lessons and problems