### PR TITLE
Fixed Module Ordering

### DIFF
--- a/src/api/dal/course.ts
+++ b/src/api/dal/course.ts
@@ -6,12 +6,15 @@ import { Course } from '../models/v2/course.model';
 import { Module } from '../models/v2/module.model';
 import { Problem } from '../models/v2/problem.model';
 import { Lesson } from '../models/v2/lesson.model';
+import { Sequelize } from 'sequelize';
+
+// import { Sequelize } from 'sequelize';
 
 export const create = async (
   payload: CourseAttributesInput
 ): Promise<CourseAttributes> => {
   const course = await Course.create(payload);
-  return course.dataValues;
+  return course.get({ plain: true });
 };
 
 export const getById = async (
@@ -37,7 +40,7 @@ export const updateById = async (
     return undefined;
   }
   const updatedCourse = await course.update(payload);
-  return updatedCourse.dataValues;
+  return updatedCourse.get({ plain: true });
 };
 
 export const getAll = async (
@@ -61,7 +64,9 @@ export const getStructure = async (
       {
         model: Module,
         as: 'modules',
-        attributes: ['id', 'moduleName'],
+        attributes: ['id', 'moduleName', 'orderNumber'],
+        separate: true,
+        order: [['orderNumber', 'ASC']],
         include: [
           {
             model: Problem,
@@ -91,4 +96,26 @@ export const getStructure = async (
   });
 
   return course ? course.get({ plain: true }) : null;
+};
+
+export const getNextOrder = async (id: string): Promise<number> => {
+  const course = await Course.findAll({
+    attributes: [
+      [Sequelize.fn('COUNT', Sequelize.col('modules.id')), 'moduleCount']
+    ],
+    include: [
+      {
+        model: Module,
+        as: 'modules',
+        required: false,
+        attributes: []
+      }
+    ],
+    group: ['Course.id'],
+    where: {
+      id: id
+    }
+  });
+  const prevMax = course[0].get({ plain: true })['moduleCount'];
+  return prevMax + 1;
 };

--- a/src/api/dal/course.ts
+++ b/src/api/dal/course.ts
@@ -8,8 +8,6 @@ import { Problem } from '../models/v2/problem.model';
 import { Lesson } from '../models/v2/lesson.model';
 import { Sequelize } from 'sequelize';
 
-// import { Sequelize } from 'sequelize';
-
 export const create = async (
   payload: CourseAttributesInput
 ): Promise<CourseAttributes> => {

--- a/src/api/models/v2/module.model.ts
+++ b/src/api/models/v2/module.model.ts
@@ -9,7 +9,10 @@ export interface ModuleAttributes {
   courseId?: string;
 }
 
-export type ModuleAttributesInput = Optional<ModuleAttributes, 'id'>;
+export type ModuleAttributesInput = Optional<
+  ModuleAttributes,
+  'id' | 'orderNumber'
+>;
 
 type ModuleInstance = Model<ModuleAttributes, ModuleAttributesInput>;
 

--- a/src/api/routes/v2/course.routes.ts
+++ b/src/api/routes/v2/course.routes.ts
@@ -4,7 +4,8 @@ import {
   deleteCourse,
   getCourseById,
   updateCourse,
-  getCourseStructure
+  getCourseStructure,
+  changeModuleOrder
 } from '../../controllers/v2/course.controller';
 const courseRouter = Router();
 
@@ -15,5 +16,6 @@ courseRouter
   .put(updateCourse)
   .get(getCourseById);
 courseRouter.route('/:courseId/structure').get(getCourseStructure);
+courseRouter.route('/:courseId/changeModuleOrder').post(changeModuleOrder);
 
 export { courseRouter };


### PR DESCRIPTION
- Added sorting by module order to course structure retrieval
- Added `/course/{courseId}/changeModuleOrder` route, operates the same way as changing order for problems and lessons except you don't need to add the `contentType` variable