### PR TITLE
updated invitation and enrollment routes

### DIFF
--- a/src/api/controllers/v2/enrollment.controller.ts
+++ b/src/api/controllers/v2/enrollment.controller.ts
@@ -3,6 +3,19 @@ import { EnrollmentAttributes } from '../../models/v2/enrollment.model';
 import * as EnrollmentDataLayer from '../../dal/enrollment';
 import { WithAuthProp } from '@clerk/clerk-sdk-node';
 
+export const getUserEnrollments = async (
+  req: WithAuthProp<Request>,
+  res: Response
+): Promise<Response<any, Record<string, any>>> => {
+  try {
+    const enrollments = await EnrollmentDataLayer.getByUser(req.auth.userId);
+    if (!enrollments) return res.status(404).send();
+    else return res.status(200).send(enrollments);
+  } catch (e) {
+    return res.status(500).send(e.message);
+  }
+};
+
 export const getRoster = async (
   req: WithAuthProp<Request>,
   res: Response

--- a/src/api/dal/enrollment.ts
+++ b/src/api/dal/enrollment.ts
@@ -2,6 +2,31 @@ import {
   Enrollment,
   EnrollmentAttributes
 } from '../models/v2/enrollment.model';
+import { Course } from '../models/v2/course.model';
+
+import { sequelize } from '../../config/database_v2';
+
+export const getByUser = async (
+  userId: string
+): Promise<EnrollmentAttributes[]> => {
+  const enrollment = await Enrollment.findAll({
+    include: [
+      {
+        model: Course,
+        as: 'course',
+        attributes: []
+      }
+    ],
+    attributes: {
+      include: [[sequelize.col('course.courseName'), 'courseName']]
+    },
+    where: {
+      userId
+    },
+    order: [['courseName', 'ASC']]
+  });
+  return enrollment.map((value) => value.get({ plain: true }));
+};
 
 export const getAllCourseEnrollments = async (
   courseId: string

--- a/src/api/dal/enrollment.ts
+++ b/src/api/dal/enrollment.ts
@@ -4,12 +4,14 @@ import {
 } from '../models/v2/enrollment.model';
 import { Course } from '../models/v2/course.model';
 
+import * as clerk from '../services/clerk';
+
 import { sequelize } from '../../config/database_v2';
 
 export const getByUser = async (
   userId: string
 ): Promise<EnrollmentAttributes[]> => {
-  const enrollment = await Enrollment.findAll({
+  const result = await Enrollment.findAll({
     include: [
       {
         model: Course,
@@ -18,26 +20,71 @@ export const getByUser = async (
       }
     ],
     attributes: {
-      include: [[sequelize.col('course.courseName'), 'courseName']]
+      include: [
+        [sequelize.col('course.courseName'), 'courseName'],
+        [
+          sequelize.literal(
+            `(SELECT GROUP_CONCAT(userId) FROM Enrollment WHERE courseId=course.id AND role='instructor')`
+          ),
+          'instructors'
+        ]
+      ]
     },
     where: {
       userId
     },
     order: [['courseName', 'ASC']]
   });
-  return enrollment.map((value) => value.get({ plain: true }));
+
+  const enrollments: any = result.map((value) => value.get({ plain: true }));
+  await Promise.all(
+    enrollments.map(async (enrollment: any) => {
+      const ids = enrollment.instructors.split(',');
+      const names = await clerk.getUsers(ids).then((users) => {
+        return users.map((user) =>
+          !user.firstName || !user.lastName
+            ? ''
+            : user.firstName + ' ' + user.lastName
+        );
+      });
+      enrollment.instructors = names;
+      return enrollment;
+    })
+  );
+
+  return enrollments;
 };
 
 export const getAllCourseEnrollments = async (
   courseId: string
 ): Promise<EnrollmentAttributes[]> => {
-  const enrollment = await Enrollment.findAll({
+  const result = await Enrollment.findAll({
     where: {
       courseId
     },
     order: [['email', 'ASC']]
   });
-  return enrollment.map((value) => value.get({ plain: true }));
+  let enrollments: any = result.map((value) => value.get({ plain: true }));
+
+  const userIds = enrollments.map((value) => value.userId);
+  const users = await clerk.getUsers(userIds);
+
+  const names = new Map<string, string>();
+  users.forEach((user) => {
+    names.set(
+      user.id,
+      !user.firstName || !user.lastName
+        ? ''
+        : user.firstName + ' ' + user.lastName
+    );
+  });
+
+  enrollments = enrollments.map((value) => {
+    value['name'] = names.get(value.userId);
+    return value;
+  });
+
+  return enrollments;
 };
 
 export const create = async (

--- a/src/api/dal/invitation.ts
+++ b/src/api/dal/invitation.ts
@@ -5,6 +5,7 @@ import {
   InvitationAttributesInput
 } from '../models/v2/invitation.model';
 import { Enrollment } from '../models/v2/enrollment.model';
+import { Course } from '../models/v2/course.model';
 
 import { sequelize } from '../../config/database_v2';
 
@@ -24,6 +25,16 @@ export const getByEmails = async (
   emails: string[]
 ): Promise<InvitationAttributes[]> => {
   const invitations = await Invitation.findAll({
+    include: [
+      {
+        model: Course,
+        as: 'course',
+        attributes: []
+      }
+    ],
+    attributes: {
+      include: [[sequelize.col('course.courseName'), 'courseName']]
+    },
     where: {
       email: emails
     }

--- a/src/api/models/v2/enrollment.model.ts
+++ b/src/api/models/v2/enrollment.model.ts
@@ -1,6 +1,8 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../../../config/database_v2';
 
+import { Course } from './course.model';
+
 export interface EnrollmentAttributes {
   userId: string;
   courseId: string;
@@ -41,3 +43,15 @@ export const Enrollment = sequelize.define<EnrollmentInstance>(
     freezeTableName: true
   }
 );
+
+Enrollment.belongsTo(Course, {
+  constraints: false,
+  as: 'course',
+  foreignKey: 'courseId'
+});
+
+Course.hasMany(Enrollment, {
+  constraints: false,
+  as: 'enrollments',
+  foreignKey: 'courseId'
+});

--- a/src/api/models/v2/invitation.model.ts
+++ b/src/api/models/v2/invitation.model.ts
@@ -1,9 +1,11 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import { sequelize } from '../../../config/database_v2';
 
+import { Course } from './course.model';
+
 export interface InvitationAttributes {
   id: string;
-  courseId: string;
+  courseId?: string;
   role: 'teachingAssistant' | 'instructor' | 'student';
   email: string;
 }
@@ -19,10 +21,6 @@ export const Invitation = sequelize.define<InvitationInstance>(
       type: DataTypes.STRING,
       primaryKey: true
     },
-    courseId: {
-      type: DataTypes.STRING,
-      allowNull: false
-    },
     email: {
       type: DataTypes.STRING,
       allowNull: false
@@ -36,3 +34,15 @@ export const Invitation = sequelize.define<InvitationInstance>(
     freezeTableName: true
   }
 );
+
+Invitation.belongsTo(Course, {
+  constraints: false,
+  as: 'course',
+  foreignKey: 'courseId'
+});
+
+Course.hasMany(Invitation, {
+  constraints: false,
+  as: 'invitations',
+  foreignKey: 'courseId'
+});

--- a/src/api/routes/v3/enrollment.routes.ts
+++ b/src/api/routes/v3/enrollment.routes.ts
@@ -1,0 +1,9 @@
+import * as express from 'express';
+
+import { getUserEnrollments } from '../../controllers/v2/enrollment.controller';
+
+const router = express.Router();
+
+router.route('/').get(getUserEnrollments);
+
+export default router;

--- a/src/api/routes/v3/index.ts
+++ b/src/api/routes/v3/index.ts
@@ -1,15 +1,16 @@
 import { NextFunction, Request, Response, Router } from 'express';
+import { WithAuthProp } from '@clerk/clerk-sdk-node';
+
 import courseRouter from './course.routes';
 import organizationRouter from './organization.routes';
 import moduleRouter from './module.routes';
 import { studentProblemRouter, adminProblemRouter } from './problem.routes';
 import { studentLessonRouter, adminLessonRouter } from './lesson.routes';
 import invitationRouter from './invitation.routes';
+import enrollmentRouter from './enrollment.routes';
 import codeRouter from './code.routes';
 
 import { clerk } from '../../services/clerk';
-
-import { WithAuthProp } from '@clerk/clerk-sdk-node';
 
 const router = Router();
 router.use(clerk.expressWithAuth());
@@ -29,5 +30,6 @@ router.use('/admin/problem', adminProblemRouter);
 router.use('/student/lesson', studentLessonRouter);
 router.use('/admin/lesson', adminLessonRouter);
 router.use('/invitations', invitationRouter);
+router.use('/enrollments', enrollmentRouter);
 
 export default router;

--- a/src/api/routes/v3/invitation.routes.ts
+++ b/src/api/routes/v3/invitation.routes.ts
@@ -8,7 +8,6 @@ import {
 
 const router = express.Router();
 
-// TODO: add course invitation routes to ./course.routes.ts
 router.route('/').get(getUserInvitations);
 router.route('/:invitationId/accept').post(acceptInvitation);
 router.route('/:invitationId/reject').post(rejectInvitation);

--- a/src/api/services/clerk.ts
+++ b/src/api/services/clerk.ts
@@ -8,3 +8,8 @@ export const getUser = async (userId: string): Promise<User> => {
   const user = await clerk.users.getUser(userId);
   return user;
 };
+
+export const getUsers = async (userIds: string[]): Promise<User[]> => {
+  const users = await clerk.users.getUserList({ userId: userIds });
+  return users;
+};

--- a/src/config/express.ts
+++ b/src/config/express.ts
@@ -72,8 +72,8 @@ class Server {
     await Problem.sync();
     await TestCase.sync();
     await Lesson.sync();
-    await Invitation.sync();
-    await Enrollment.sync();
+    await Invitation.sync({ alter: true });
+    await Enrollment.sync({ alter: true });
   }
 
   public start(): void {

--- a/src/config/express.ts
+++ b/src/config/express.ts
@@ -72,8 +72,8 @@ class Server {
     await Problem.sync();
     await TestCase.sync();
     await Lesson.sync();
-    await Invitation.sync({ alter: true });
-    await Enrollment.sync({ alter: true });
+    await Invitation.sync();
+    await Enrollment.sync();
   }
 
   public start(): void {


### PR DESCRIPTION
- Created course associations for invitation and enrollment models
    - User invitation and enrollment retrievals now also return course name
 - Created base enrollment route to view user enrollments (`GET /enrollments`)
 - Returns names of students in course enrollment, as well as instructor names when retrieving user enrollments and invitations

Seems to work on Postman, maybe we should try integrating it with front-end as well